### PR TITLE
Initial IPv6 support

### DIFF
--- a/patches/jdk17u_android.diff
+++ b/patches/jdk17u_android.diff
@@ -2284,6 +2284,19 @@ index 503a2457b..d6ac325c8 100644
  #endif
  
      if (exec_path == NULL) {
+diff --git a/src/java.base/unix/native/libnet/net_util_md.c b/src/java.base/unix/native/libnet/net_util_md.c
+index 7c939e80f..92bec981e 100644
+--- a/src/java.base/unix/native/libnet/net_util_md.c
++++ b/src/java.base/unix/native/libnet/net_util_md.c
+@@ -154,7 +154,7 @@ jint  IPv6_supported()
+      * Linux - check if any interface has an IPv6 address.
+      * Don't need to parse the line - we just need an indication.
+      */
+-#ifdef __linux__
++#if defined(__linux__) && !defined(__ANDROID__)
+     {
+         FILE *fP = fopen("/proc/net/if_inet6", "r");
+         char buf[255];
 diff --git a/src/java.base/unix/native/libnet/net_util_md.h b/src/java.base/unix/native/libnet/net_util_md.h
 index 68835987b..eafd4509e 100644
 --- a/src/java.base/unix/native/libnet/net_util_md.h

--- a/patches/jdk17u_android.diff
+++ b/patches/jdk17u_android.diff
@@ -336,8 +336,8 @@ index 3c9d1055f..e4260da69 100644
  
  ################################################################################
  
--ifeq ($(call isTargetOs, linux macosx), true)
-+ifeq ($(call isTargetOs, linux macosx android), true)
+-ifeq ($(call isTargetOs, linux macosx windows), true)
++ifeq ($(call isTargetOs, linux macosx windows android), true)
  
    $(eval $(call SetupJdkLibrary, BUILD_LIBEXTNET, \
        NAME := extnet, \


### PR DESCRIPTION
Skip /proc/net/ check to make ipv6 usable on android. _Works on my machine._
Reference: https://android.googlesource.com/platform/libcore/+/ae218d9bdc8395ac0ed9278c86cff597915c2a7b%5E%21
(I don't know why this is not a selinux issue)
should able to close https://github.com/FCL-Team/FoldCraftLauncher/issues/360 and related issues.
(Note there is a additional patch to fix `git patch` producing .rej file, Maintainers may need to split the PR to two parts.)